### PR TITLE
Run the integration tests without the transaction mining delay

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ jobs:
           command: |
             git submodule sync
             git submodule update --init --remote --recursive
-      - run: docker-compose build --no-cache
+      - run: docker-compose build
       - *collect-docker-compose-logs
       - *collect-arweave-logs
       - run:

--- a/core/src/it/scala/co/upvest/arweave4s/ApiTestUtil.scala
+++ b/core/src/it/scala/co/upvest/arweave4s/ApiTestUtil.scala
@@ -1,17 +1,16 @@
 package co.upvest.arweave4s
 
-import co.upvest.arweave4s.adt.{Data, Transaction, Wallet, Winston}
+import co.upvest.arweave4s.adt.{Data, Wallet, Winston}
 import co.upvest.arweave4s.utils.CryptoUtils
 import com.softwaremill.sttp.{Uri, UriContext}
 
 import scala.util.{Random, Try}
-import scala.concurrent.duration._
 import scala.io.Source
 
 object ApiTestUtil {
 
   val NotExistingTestHost: Uri = uri"127.0.0.1:9"
-  val TestHost: Uri = uri"${(sys.env get "TESTNET_HOST" getOrElse "localhost") + ":1984"}"
+  val TestHost: Uri = uri"${(sys.env get "TESTNET_HOST" getOrElse "localhost:1984")}"
 
   object TestAccount {
     lazy val wallet: Wallet = (
@@ -29,11 +28,6 @@ object ApiTestUtil {
       ) get
 
     lazy val address = wallet.address
-  }
-
-  def waitForDataTransaction(t: Transaction.Data): Unit = {
-    // https://github.com/ArweaveTeam/arweave/blob/d6109b7ad7d824fcea8a540b055c6fb6602b1c81/src/ar_node.erl#L1461
-    Thread.sleep(((30 seconds) + (t.data.size * 300 milliseconds) / 1000).toMillis)
   }
 
   def randomWinstons(

--- a/core/src/it/scala/co/upvest/arweave4s/apiExamples.scala
+++ b/core/src/it/scala/co/upvest/arweave4s/apiExamples.scala
@@ -107,8 +107,6 @@ class apiExamples extends WordSpec
 
 
       whenReady(f) { stx =>
-        waitForDataTransaction(stx)
-
         And("eventually get accepted")
         eventually {
           whenReady(api.tx.get[Future](stx.id)) { ts =>

--- a/core/src/it/scala/co/upvest/arweave4s/apiSpec.scala
+++ b/core/src/it/scala/co/upvest/arweave4s/apiSpec.scala
@@ -256,8 +256,6 @@ class apiSpec extends WordSpec
 
           run { tx.submit(stx) } shouldBe (())
 
-          waitForDataTransaction(stx)
-
           eventually {
             inside(run { tx.get[F](stx.id) }) {
               case Transaction.WithStatus.Accepted(t) =>

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,10 +4,13 @@ services:
     build:
       context: arweave
       args:
-        ERLC_OPTS: "-DFIXED_DIFF=4"
+        ERLC_OPTS: "-DFIXED_DIFF=4 -DFIXED_DELAY=0"
     ports:
       - "1984:1984"
-    command: no_auto_join init mine peer 127.0.0.1:9
+    entrypoint:
+      - "/bin/sh"
+      - "-c"
+      - "echo ADECEEQHldVB55AQRg6cq_hhFGKnJiVKN0pRuvp3Sms,1000000 > data/genesis_wallets.csv && ./arweave-server no_auto_join init mine peer 127.0.0.1:9"
     cpus: 0.5
   it:
     build:
@@ -17,4 +20,4 @@ services:
     depends_on:
       - arweave
     environment:
-      TESTNET_HOST: arweave
+      TESTNET_HOST: http://arweave:1984


### PR DESCRIPTION
@allquantor also note that the test key is added to the genesis block in here instead of in https://github.com/ArweaveTeam/arweave/pull/11/